### PR TITLE
Changed Service connection name for publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,4 @@ FodyWeavers.xsd
 # Additional files built by Visual Studio
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudio
+/.idea/.idea.Fhi.VersionApi/.idea/**

--- a/VersionApi.Azure.Publish.yaml
+++ b/VersionApi.Azure.Publish.yaml
@@ -86,7 +86,7 @@ stages:
             - task: AzureWebApp@1
               displayName: 'Azure App Service Deploy: website'
               inputs:
-                azureSubscription: 'FHI-Utvikling'
+                azureSubscription: 'FHI-Utvikling-VersionAPI'
                 appName: '$(appname)'
                 slotName: 'production'
                 package: '$(Pipeline.Workspace)/drop/$(buildConfiguration)/*.zip'

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,7 +1,8 @@
-mode: Mainline
 branches:
-  master:
-    regex: ^master$|^main$|^develop$
+  develop:
+    regex: ^develop$
+  main:
+    regex: ^main$
 ignore:
   sha: []
 merge-message-formats: {}


### PR DESCRIPTION
- This bypasses original problem related to expired secret for Azure App Registration by using a new Service Connection that has also been update to use Workload Identity Federation so should not expire in the future.
- Had to include GitVersion.yml changes from https://github.com/FHIDev/Fhi.VersionApi/pull/9 to get it to build